### PR TITLE
Updating Google Drive Picker View.

### DIFF
--- a/client/psychic-modal/src/components/auth/GDriveMetadataForm.tsx
+++ b/client/psychic-modal/src/components/auth/GDriveMetadataForm.tsx
@@ -42,7 +42,7 @@ const GDriveMetadataForm: React.FC<GDriveMetadataFormProps> = ({creds, onSubmit}
           appId: appId,
           clientId: credsJson.client_id,
           developerKey: credsJson.developer_key,
-          viewId: "DOCUMENTS",
+          viewId: "PDFS",
           token: credsJson.access_token, // pass oauth token in case you already have one
           showUploadView: false,
           showUploadFolders: false,

--- a/client/psychic-modal/src/components/auth/GDriveMetadataForm.tsx
+++ b/client/psychic-modal/src/components/auth/GDriveMetadataForm.tsx
@@ -42,7 +42,7 @@ const GDriveMetadataForm: React.FC<GDriveMetadataFormProps> = ({creds, onSubmit}
           appId: appId,
           clientId: credsJson.client_id,
           developerKey: credsJson.developer_key,
-          viewId: "DOCS",
+          viewId: "DOCUMENTS",
           token: credsJson.access_token, // pass oauth token in case you already have one
           showUploadView: false,
           showUploadFolders: false,


### PR DESCRIPTION
The backend supports PDFs (https://github.com/psychic-api/psychic/blob/main/server/connectors/google_drive_connector/google_drive_connector.py). Docx can be exported from Google API into PDF as well.

The current view, "DOCS" allows users to select any files that are MIME-types supported by Gdrive -- Could be Drawings, SpreadSheets, iPynb etc. Even if the handling for random files is fine on the backend, the users would probably expect the files they selected to be successfully uploaded. Better to handle "DOCUMENTS" (Google Drive Documents -- google docs)
 or "PDFS" view to show exclusively the kind of docs we can process for now. 
 
Also, should be fairly straightforward to support Most types from Google Drive (Sheets, Docx, PDFs) mainly using Unstructured loader // Random files with textual data can also be read using UnstructuredFileLoader.